### PR TITLE
feat: add "Show More" functionality for related elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Related Elements
 
+## Unreleased
+### Added
+- "Show More" functionality to limit visible related elements with configurable initial limit.
+- New `initialLimit` setting to control how many elements are shown initially (default: 10).
+
 ## 1.1.4 - 2025-04-28
 ### Fixed
 - Error handling for related elements without fieldLayout.

--- a/README.md
+++ b/README.md
@@ -40,5 +40,11 @@ Configure options in the control panel under Settings → Related Elements or cr
 
 return [
     'enableNestedElements' => true,
+    'initialLimit' => 10,
 ];
 ```
+
+### Settings
+
+- **enableNestedElements** (boolean, default: `true`) - Whether to display the related elements that exist inside the Matrix or Neo fields of an element.
+- **initialLimit** (integer, default: `10`) - Number of related elements to show initially before requiring "Show More" to expand the list.

--- a/src/RelatedElements.php
+++ b/src/RelatedElements.php
@@ -114,6 +114,7 @@ class RelatedElements extends Plugin
                 'hasResults' => $hasResults,
                 'relatedElements' => $relatedElements,
                 'nestedRelatedElements' => $nestedRelatedElements,
+                'initialLimit' => self::$settings->initialLimit,
             ]
         );
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -7,4 +7,14 @@ use craft\base\Model;
 class Settings extends Model
 {
     public bool $enableNestedElements = true;
+    public int $initialLimit = 10;
+
+    public function rules(): array
+    {
+        return [
+            [['enableNestedElements'], 'boolean'],
+            [['initialLimit'], 'integer', 'min' => 1, 'max' => 100],
+            [['initialLimit'], 'default', 'value' => 10],
+        ];
+    }
 }

--- a/src/templates/_element-sidebar.twig
+++ b/src/templates/_element-sidebar.twig
@@ -2,10 +2,27 @@
   <legend class="h6">Related elements</legend>
   <div class="meta">
     {% if hasResults %}
+      {% set totalElements = 0 %}
+      {% for key, section in relatedElements %}
+        {% if section|length %}
+          {% set totalElements = totalElements + section|length %}
+        {% endif %}
+      {% endfor %}
+      {% for fieldKey, field in nestedRelatedElements %}
+        {% for key, section in field %}
+          {% if section|length %}
+            {% set totalElements = totalElements + section|length %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+
+      {% set elementIndex = 0 %}
+
       {% for key, section in relatedElements %}
         {% if section|length %}
           {% for element in section %}
-            <div class="field" style="padding-block: 12px; padding-inline: var(--m) var(--s);">
+            {% set elementIndex = elementIndex + 1 %}
+            <div class="field related-element-item" data-index="{{ elementIndex - 1 }}" style="padding-block: 12px; padding-inline: var(--m) var(--s);">
               <a href="{{ element.cpEditUrl ?? '#' }}" class="flex flex-nowrap gap-s">
                 <span class="status small {{ element.status }}" role="img" aria-label="Status: {{ element.status }}" style="margin-inline-end: 0;"></span>
                 <span class="cp-icon small">
@@ -26,6 +43,7 @@
           {% endfor %}
         {% endif %}
       {% endfor %}
+
       {% for fieldKey, field in nestedRelatedElements %}
         {% set hasFieldElements = false %}
         {% for section in field %}
@@ -35,15 +53,15 @@
         {% endfor %}
 
         {% if hasFieldElements %}
-          <div class="field" style="padding-block: 12px; padding-inline: var(--m) var(--s);">
-            <em>
-              {{ fieldKey }}
-            </em>
+          {% set headerIndex = elementIndex %}
+          <div class="field nested-field-header" data-index="{{ headerIndex }}" style="padding-block: 12px; padding-inline: var(--m) var(--s);">
+            <em>{{ fieldKey }}</em>
           </div>
           {% for key, section in field %}
             {% if section|length %}
               {% for element in section %}
-                <div class="field" style="min-height: 34px; padding-top: 0; padding-bottom: 12px; border-top: none;">
+                {% set elementIndex = elementIndex + 1 %}
+                <div class="field related-element-item" data-index="{{ elementIndex - 1 }}" data-header="{{ headerIndex }}" style="min-height: 34px; padding-top: 0; padding-bottom: 12px; border-top: none;">
                   <div class="flex flex-nowrap gap-s" style="padding-left: var(--m);">
                     <span style="position: relative; top: -3px;">∟</span>
                     <a href="{{ element.cpEditUrl ?? '#' }}" class="flex flex-nowrap gap-s">
@@ -69,6 +87,17 @@
           {% endfor %}
         {% endif %}
       {% endfor %}
+
+      {% if totalElements > (initialLimit ?? 10) %}
+        <div class="field show-more-container" style="padding-block: 6px; padding-inline: var(--m) var(--s); border-top: none;">
+          <button type="button" class="btn small show-more-btn">
+            Show {{ totalElements - (initialLimit ?? 10) }} more related elements
+          </button>
+          <button type="button" class="btn small show-less-btn" style="display: none;">
+            Show less
+          </button>
+        </div>
+      {% endif %}
     {% else %}
       <div class="field flex-1">
         <div style="padding-block: 12px; padding-inline: var(--m) var(--s);">
@@ -78,3 +107,88 @@
     {% endif %}
   </div>
 </fieldset>
+
+<script>
+  (function() {
+    'use strict';
+
+    const initialLimit = {{ initialLimit ?? 10 }};
+
+    function initializeRelatedElements() {
+      const items = document.querySelectorAll('.related-elements-sidebar .related-element-item[data-index]');
+      const headers = document.querySelectorAll('.related-elements-sidebar .nested-field-header[data-index]');
+      const showMoreBtn = document.querySelector('.related-elements-sidebar .show-more-btn');
+      const showLessBtn = document.querySelector('.related-elements-sidebar .show-less-btn');
+
+      if (items.length <= initialLimit) {
+        return;
+      }
+
+      function hideElementsAndHeaders() {
+        items.forEach(function(item, index) {
+          if (index >= initialLimit) {
+            item.style.display = 'none';
+          }
+        });
+
+        headers.forEach(function(header) {
+          const headerIndex = parseInt(header.getAttribute('data-index'));
+          const relatedElements = document.querySelectorAll('.related-element-item[data-header="' + headerIndex + '"]');
+          let hasVisibleElements = false;
+
+          relatedElements.forEach(function(element) {
+            if (element.style.display !== 'none') {
+              hasVisibleElements = true;
+            }
+          });
+
+          if (!hasVisibleElements) {
+            header.style.display = 'none';
+          } else {
+            header.style.display = '';
+          }
+        });
+      }
+
+      function showAllElementsAndHeaders() {
+        items.forEach(function(item) {
+          item.style.display = '';
+        });
+
+        headers.forEach(function(header) {
+          header.style.display = '';
+        });
+      }
+
+      hideElementsAndHeaders();
+
+      if (showMoreBtn) {
+        showMoreBtn.addEventListener('click', function(e) {
+          e.preventDefault();
+          showAllElementsAndHeaders();
+          showMoreBtn.style.display = 'none';
+          if (showLessBtn) {
+            showLessBtn.style.display = '';
+          }
+        });
+      }
+
+      if (showLessBtn) {
+        showLessBtn.addEventListener('click', function(e) {
+          e.preventDefault();
+          hideElementsAndHeaders();
+          showLessBtn.style.display = 'none';
+          if (showMoreBtn) {
+            showMoreBtn.style.display = '';
+          }
+        });
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initializeRelatedElements);
+    } else {
+      setTimeout(initializeRelatedElements, 100);
+    }
+  })();
+</script>

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -8,5 +8,16 @@
     on: (settings.enableNestedElements is defined) ? settings.enableNestedElements : '',
     class: 'first',
   }) }}
+
+  {{ forms.textField({
+    label: 'Initial limit',
+    instructions: 'Number of related elements to show initially before requiring "Show More" to expand the list.',
+    name: 'initialLimit',
+    value: settings.initialLimit,
+    type: 'number',
+    min: 1,
+    max: 100,
+    size: 10,
+  }) }}
 </div>
 


### PR DESCRIPTION
- Introduced a new `initialLimit` setting to control the number of related elements displayed initially (default: 10).
- Updated the UI to include a "Show More" button that expands the list of related elements when clicked.
- Enhanced the settings page to allow configuration of the `initialLimit` value.